### PR TITLE
Add Moneris hosted checkout demo and helper server

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -32,5 +32,32 @@ Credits:
 		Font Awesome (fontawesome.io)
 
 	Other:
-		jQuery (jquery.com)
-		Responsive Tools (github.com/ajlkn/responsive-tools)
+                jQuery (jquery.com)
+                Responsive Tools (github.com/ajlkn/responsive-tools)
+
+Moneris Checkout & Hosted Tokenization Demo
+==========================================
+
+This repo now ships with a working example of the Moneris hosted checkout and hosted
+tokenization flows. Follow the steps below to try a QA purchase using your Moneris test
+credentials.
+
+1. Install dependencies: `npm install`
+2. Export your credentials (replace the placeholders with your QA keys):
+
+        export MONERIS_STORE_ID=store5
+        export MONERIS_API_TOKEN=yourapitoken
+        # Optional overrides
+        export MONERIS_ENV=qa
+        export MONERIS_DESCRIPTOR="Demo Shop"
+
+3. Start the helper API: `npm run moneris:server`
+4. Browse to `http://localhost:5174/moneris-checkout.html`. Use the form to request a
+   checkout session and then click **Launch Moneris Checkout** to complete a test
+   transaction.
+5. Use the **Load hosted tokenization** button to embed Moneris' iframe after you set
+   the `data-moneris-tokenization-id` attribute on the page with your profile ID.
+
+Refer to the Moneris documentation for optional fields (billing address, recurring
+payments, etc.) and extend `server/moneris-checkout-server.js` to include them before
+requesting a checkout session.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3068,3 +3068,35 @@ input, select, textarea {
 			}
 
 	}
+/* Moneris demo tweaks */
+.moneris-guide .moneris-form label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 0.35rem;
+}
+
+.moneris-guide .moneris-form input,
+.moneris-guide .moneris-form select {
+        width: 100%;
+}
+
+.moneris-guide pre {
+        background: rgba(0, 0, 0, 0.05);
+        border-radius: 0.35rem;
+        padding: 1rem;
+        overflow-x: auto;
+        font-family: "Source Code Pro", monospace;
+        font-size: 0.9rem;
+}
+
+.moneris-guide .moneris-status {
+        margin-top: 1.5rem;
+}
+
+.moneris-tokenization {
+        margin-top: 1.5rem;
+}
+
+.moneris-tokenization button {
+        margin-bottom: 1rem;
+}

--- a/assets/js/moneris-checkout.js
+++ b/assets/js/moneris-checkout.js
@@ -1,0 +1,277 @@
+(function () {
+  const form = document.getElementById('moneris-options');
+  const launchButton = document.getElementById('launch-checkout');
+  const statusEl = document.getElementById('moneris-status');
+  const eventsEl = document.getElementById('moneris-events');
+  const tokenButton = document.getElementById('load-tokenizer');
+  const tokenizerContainer = document.getElementById('moneris-tokenizer');
+  const tokenizerOutput = document.getElementById('tokenization-output');
+
+  if (!form || !statusEl) {
+    return;
+  }
+
+  let checkoutConfig = null;
+  let checkoutInstance = null;
+  let eventsBound = false;
+
+  function setStatus(message) {
+    if (!statusEl) return;
+    statusEl.textContent = message;
+  }
+
+  function logEvent(name, payload) {
+    if (!eventsEl) return;
+    const entry = {
+      event: name,
+      timestamp: new Date().toISOString(),
+      payload,
+    };
+    eventsEl.textContent = JSON.stringify(entry, null, 2) + '\n\n' + (eventsEl.textContent || '');
+  }
+
+  function resetCheckout() {
+    checkoutConfig = null;
+    if (launchButton) {
+      launchButton.disabled = true;
+    }
+  }
+
+  async function requestCheckout(data) {
+    setStatus('Requesting checkout session…');
+    resetCheckout();
+
+    const response = await fetch('/api/moneris/checkout', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ message: response.statusText }));
+      throw new Error(error.message || 'Failed to request checkout session.');
+    }
+
+    return response.json();
+  }
+
+  function resolveCheckoutInstance() {
+    if (checkoutInstance) {
+      return checkoutInstance;
+    }
+
+    const ctor = window.MonerisCheckout;
+    if (typeof ctor === 'function') {
+      try {
+        checkoutInstance = new ctor();
+        eventsBound = false;
+        return checkoutInstance;
+      } catch (error) {
+        console.warn('Unable to instantiate MonerisCheckout', error);
+      }
+    }
+
+    if (ctor && typeof ctor.configure === 'function') {
+      checkoutInstance = ctor;
+      return checkoutInstance;
+    }
+
+    return null;
+  }
+
+  function applyConfig(instance, config) {
+    if (!instance || !config) return;
+
+    if (typeof instance.setCheckoutId === 'function') {
+      instance.setCheckoutId(config.checkoutId);
+    }
+    if (typeof instance.setEnvironment === 'function') {
+      instance.setEnvironment(config.environment);
+    }
+    if (typeof instance.setMode === 'function') {
+      instance.setMode(config.environment);
+    }
+    if (typeof instance.configure === 'function') {
+      instance.configure(config);
+    }
+
+    const events = instance.Events || window.MonerisCheckout?.Events;
+    if (!eventsBound && events && typeof instance.addEventListener === 'function') {
+      eventsBound = true;
+      if (events.PAYMENT_COMPLETE) {
+        instance.addEventListener(events.PAYMENT_COMPLETE, (payload) => {
+          logEvent('payment_complete', payload);
+          setStatus('Payment complete. See event log for details.');
+        });
+      }
+      if (events.CANCEL) {
+        instance.addEventListener(events.CANCEL, (payload) => {
+          logEvent('cancel', payload);
+          setStatus('Checkout cancelled by shopper.');
+        });
+      }
+      if (events.ERROR) {
+        instance.addEventListener(events.ERROR, (payload) => {
+          logEvent('error', payload);
+          setStatus('Checkout reported an error.');
+        });
+      }
+      return;
+    }
+
+    if (!eventsBound && typeof instance.setCallback === 'function') {
+      eventsBound = true;
+      instance.setCallback(function (eventName, payload) {
+        logEvent(eventName, payload);
+        if (eventName === 'payment_complete') {
+          setStatus('Payment complete.');
+        } else if (eventName === 'cancel') {
+          setStatus('Checkout cancelled by shopper.');
+        } else if (eventName === 'error') {
+          setStatus('Checkout reported an error.');
+        }
+      });
+    }
+  }
+
+  function startCheckout(instance, config) {
+    if (!instance) {
+      throw new Error('Moneris Checkout SDK is not available.');
+    }
+
+    if (typeof instance.startCheckout === 'function') {
+      instance.startCheckout();
+      return;
+    }
+
+    if (typeof instance.show === 'function') {
+      instance.show();
+      return;
+    }
+
+    if (typeof window.MonerisCheckout === 'function' && typeof window.MonerisCheckout.startCheckout === 'function') {
+      window.MonerisCheckout.startCheckout(config.checkoutId);
+      return;
+    }
+
+    if (typeof window.MonerisCheckout === 'function') {
+      window.MonerisCheckout(config);
+      return;
+    }
+
+    throw new Error('Unable to locate a launch method for the Moneris checkout SDK.');
+  }
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(form);
+    const amount = Number(formData.get('amount'));
+    const orderId = formData.get('orderId');
+    const transactionType = formData.get('transactionType');
+
+    if (!amount || amount <= 0) {
+      setStatus('Enter a valid amount before requesting a checkout session.');
+      return;
+    }
+
+    try {
+      const payload = await requestCheckout({
+        amount: amount.toFixed(2),
+        orderId,
+        transactionType,
+      });
+
+      checkoutConfig = {
+        checkoutId: payload.checkoutId,
+        environment: payload.environment || 'qa',
+      };
+
+      setStatus(`Checkout session ready. ID: ${checkoutConfig.checkoutId}`);
+      if (launchButton) {
+        launchButton.disabled = false;
+      }
+      logEvent('checkout_session', payload);
+    } catch (error) {
+      setStatus(error.message);
+      resetCheckout();
+    }
+  });
+
+  if (launchButton) {
+    launchButton.addEventListener('click', () => {
+      if (!checkoutConfig) {
+        setStatus('Request a checkout session first.');
+        return;
+      }
+
+      const instance = resolveCheckoutInstance();
+      try {
+        applyConfig(instance, checkoutConfig);
+        startCheckout(instance, checkoutConfig);
+        setStatus('Checkout launched.');
+      } catch (error) {
+        setStatus(error.message);
+      }
+    });
+  }
+
+  function writeTokenizerOutput(message) {
+    if (!tokenizerOutput) return;
+    const text = typeof message === 'string' ? message : JSON.stringify(message, null, 2);
+    tokenizerOutput.textContent = text + '\n' + (tokenizerOutput.textContent || '');
+  }
+
+  if (tokenButton && tokenizerContainer) {
+    tokenButton.addEventListener('click', () => {
+      const profileId = tokenizerContainer.dataset.monerisTokenizationId;
+      if (!profileId || profileId === 'REPLACE_WITH_PROFILE_ID') {
+        writeTokenizerOutput('Update the data-moneris-tokenization-id attribute with your profile ID.');
+        return;
+      }
+
+      const hostedLib = (window.Moneris && (window.Moneris.hostedTokenization || window.Moneris.HostedTokenization))
+        || window.hostedTokenization
+        || window.MonerisHostedTokenization;
+
+      if (!hostedLib) {
+        writeTokenizerOutput('Hosted tokenization library not loaded.');
+        return;
+      }
+
+      try {
+        const options = {
+          containerId: tokenizerContainer.id,
+          tokenizationId: profileId,
+          onTokenize: (result) => {
+            writeTokenizerOutput({ event: 'tokenize', result });
+          },
+          onError: (error) => {
+            writeTokenizerOutput({ event: 'error', error });
+          },
+          onClose: () => {
+            writeTokenizerOutput({ event: 'close' });
+          },
+        };
+
+        if (typeof hostedLib.setup === 'function') {
+          hostedLib.setup(options);
+        }
+
+        if (typeof hostedLib.start === 'function') {
+          hostedLib.start();
+        } else if (typeof hostedLib.show === 'function') {
+          hostedLib.show();
+        } else if (typeof hostedLib.open === 'function') {
+          hostedLib.open();
+        } else {
+          writeTokenizerOutput('Unable to locate a start method for hosted tokenization.');
+        }
+      } catch (error) {
+        writeTokenizerOutput(error.message);
+      }
+    });
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -44,7 +44,8 @@
 									</li>
 									<li><a href="left-sidebar.html">Left Sidebar</a></li>
 									<li class="break"><a href="right-sidebar.html">Right Sidebar</a></li>
-									<li><a href="no-sidebar.html">No Sidebar</a></li>
+                                                                        <li><a href="no-sidebar.html">No Sidebar</a></li>
+                                                                        <li><a href="moneris-checkout.html">Moneris Demo</a></li>
 								</ul>
 							</nav>
 

--- a/left-sidebar.html
+++ b/left-sidebar.html
@@ -44,7 +44,8 @@
 									</li>
 									<li><a href="left-sidebar.html">Left Sidebar</a></li>
 									<li class="break"><a href="right-sidebar.html">Right Sidebar</a></li>
-									<li><a href="no-sidebar.html">No Sidebar</a></li>
+                                                                        <li><a href="no-sidebar.html">No Sidebar</a></li>
+                                                                        <li><a href="moneris-checkout.html">Moneris Demo</a></li>
 								</ul>
 							</nav>
 

--- a/moneris-checkout.html
+++ b/moneris-checkout.html
@@ -1,0 +1,170 @@
+<!DOCTYPE HTML>
+<!--
+	Telephasic by HTML5 UP
+	html5up.net | @ajlkn
+	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+-->
+<html>
+	<head>
+                <title>Moneris Checkout Demo</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="stylesheet" href="assets/css/main.css" />
+	</head>
+	<body class="no-sidebar is-preload">
+		<div id="page-wrapper">
+
+			<!-- Header -->
+				<div id="header-wrapper">
+					<div id="header" class="container">
+
+						<!-- Logo -->
+							<h1 id="logo"><a href="index.html">Telephasic</a></h1>
+
+						<!-- Nav -->
+							<nav id="nav">
+								<ul>
+									<li>
+										<a href="#">Dropdown</a>
+										<ul>
+											<li><a href="#">Lorem ipsum dolor</a></li>
+											<li><a href="#">Magna phasellus</a></li>
+											<li><a href="#">Etiam dolore nisl</a></li>
+											<li>
+												<a href="#">Phasellus consequat</a>
+												<ul>
+													<li><a href="#">Lorem ipsum dolor</a></li>
+													<li><a href="#">Phasellus consequat</a></li>
+													<li><a href="#">Magna phasellus</a></li>
+													<li><a href="#">Etiam dolore nisl</a></li>
+												</ul>
+											</li>
+											<li><a href="#">Veroeros feugiat</a></li>
+										</ul>
+									</li>
+									<li><a href="left-sidebar.html">Left Sidebar</a></li>
+									<li class="break"><a href="right-sidebar.html">Right Sidebar</a></li>
+                                                                        <li><a href="no-sidebar.html">No Sidebar</a></li>
+                                                                        <li><a href="moneris-checkout.html">Moneris Demo</a></li>
+								</ul>
+							</nav>
+
+					</div>
+				</div>
+
+			<!-- Main -->
+				<div class="wrapper">
+					<div class="container" id="main">
+
+						<!-- Content -->
+                                                        <article id="content" class="moneris-guide">
+                                                                <header>
+                                                                        <h2>Moneris Checkout &amp; Hosted Tokenization Demo</h2>
+                                                                        <p>Use this page to spin up a QA payment session against Moneris using
+                                                                        their hosted solutions and capture the responses returned to your site.</p>
+                                                                </header>
+
+                                                                <section>
+                                                                        <h3>1. Configure your API credentials</h3>
+                                                                        <p>Store your <strong>store ID</strong> and <strong>API token</strong> as environment variables on the server that will
+                                                                        call Moneris. The sample Express server in <code>server/moneris-checkout-server.js</code>
+                                                                        expects <code>MONERIS_STORE_ID</code>, <code>MONERIS_API_TOKEN</code>, and optionally
+                                                                        <code>MONERIS_ENV</code> (defaults to <code>qa</code>).</p>
+                                                                </section>
+
+                                                                <section>
+                                                                        <h3>2. Start the demo helper API</h3>
+                                                                        <p>Install dependencies with <code>npm install</code> and start the sample server with
+                                                                        <code>npm run moneris:server</code>. The server hosts this page on
+                                                                        <code>http://localhost:5174/moneris-checkout.html</code> and exposes a
+                                                                        <code>POST /api/moneris/checkout</code> endpoint that proxies the <em>Create Checkout</em>
+                                                                        request documented by Moneris. Update the payload or headers there if you need to
+                                                                        add optional fields such as billing details.</p>
+                                                                </section>
+
+                                                                <section>
+                                                                        <h3>3. Launch Moneris Checkout from this page</h3>
+                                                                        <p>Enter the amount you want to authorize and click <em>Request Checkout Session</em>.
+                                                                        The helper API returns a checkout ID that the Moneris JavaScript SDK uses to
+                                                                        open the hosted experience. When the payment flow finishes the page logs the
+                                                                        response payloads below.</p>
+
+                                                                        <form id="moneris-options" class="moneris-form">
+                                                                                <div class="row gtr-50">
+                                                                                        <div class="col-4 col-12-mobile">
+                                                                                                <label for="purchase-amount">Amount (CAD)</label>
+                                                                                                <input id="purchase-amount" name="amount" type="number" step="0.01" min="0.01" value="10.00" required />
+                                                                                        </div>
+                                                                                        <div class="col-4 col-12-mobile">
+                                                                                                <label for="purchase-order">Order ID</label>
+                                                                                                <input id="purchase-order" name="orderId" type="text" placeholder="demo-order-001" required />
+                                                                                        </div>
+                                                                                        <div class="col-4 col-12-mobile">
+                                                                                                <label for="transaction-type">Transaction Type</label>
+                                                                                                <select id="transaction-type" name="transactionType">
+                                                                                                        <option value="purchase" selected>Purchase</option>
+                                                                                                        <option value="preauth">Pre-authorization</option>
+                                                                                                </select>
+                                                                                        </div>
+                                                                                </div>
+                                                                                <ul class="actions">
+                                                                                        <li><button type="submit" class="button primary">Request Checkout Session</button></li>
+                                                                                        <li><button id="launch-checkout" type="button" class="button" disabled>Launch Moneris Checkout</button></li>
+                                                                                </ul>
+                                                                        </form>
+
+                                                                        <div class="moneris-status">
+                                                                                <h4>Status</h4>
+                                                                                <pre id="moneris-status"></pre>
+                                                                        </div>
+
+                                                                        <div class="moneris-status">
+                                                                                <h4>Moneris Events</h4>
+                                                                                <pre id="moneris-events"></pre>
+                                                                        </div>
+                                                                </section>
+
+                                                                <section>
+                                                                        <h3>4. Hosted tokenization example</h3>
+                                                                        <p>The button below mounts the Moneris Hosted Tokenization iframe so you can
+                                                                        capture card data without it touching your servers. Replace the <code>data-moneris-tokenization-id</code>
+                                                                        attribute with the tokenization profile created in the Moneris Merchant Resource
+                                                                        Center.</p>
+
+                                                                        <div class="moneris-tokenization">
+                                                                                <button id="load-tokenizer" class="button">Load hosted tokenization</button>
+                                                                                <div id="moneris-tokenizer" data-moneris-tokenization-id="REPLACE_WITH_PROFILE_ID"></div>
+                                                                                <pre id="tokenization-output"></pre>
+                                                                        </div>
+                                                                </section>
+                                                        </article>
+					</div>
+				</div>
+
+			<!-- Footer -->
+                                <div id="footer-wrapper">
+                                        <div id="footer" class="container">
+                                                <header class="major">
+                                                        <h2>Need additional fields?</h2>
+                                                        <p>Consult the Moneris documentation to add billing information, 3-D Secure, or recurring
+                                                        payment parameters. Extend <code>assets/js/moneris-checkout.js</code> and the helper server to
+                                                        include those fields before requesting a checkout session.</p>
+                                                </header>
+                                        </div>
+                                </div>
+
+		</div>
+
+		<!-- Scripts -->
+			<script src="assets/js/jquery.min.js"></script>
+			<script src="assets/js/jquery.dropotron.min.js"></script>
+			<script src="assets/js/browser.min.js"></script>
+			<script src="assets/js/breakpoints.min.js"></script>
+                        <script src="assets/js/util.js"></script>
+                        <script src="assets/js/main.js"></script>
+                        <script src="https://gateway.moneris.com/chkt/js/chkt_v1.00.js" defer></script>
+                        <script src="https://gateway.moneris.com/chkt/js/hostedtokenization_v1.00.js" defer></script>
+                        <script src="assets/js/moneris-checkout.js" defer></script>
+
+        </body>
+</html>

--- a/no-sidebar.html
+++ b/no-sidebar.html
@@ -44,7 +44,8 @@
 									</li>
 									<li><a href="left-sidebar.html">Left Sidebar</a></li>
 									<li class="break"><a href="right-sidebar.html">Right Sidebar</a></li>
-									<li><a href="no-sidebar.html">No Sidebar</a></li>
+                                                                        <li><a href="no-sidebar.html">No Sidebar</a></li>
+                                                                        <li><a href="moneris-checkout.html">Moneris Demo</a></li>
 								</ul>
 							</nav>
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "portfolio-moneris-demo",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "moneris:server": "node server/moneris-checkout-server.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/right-sidebar.html
+++ b/right-sidebar.html
@@ -44,7 +44,8 @@
 									</li>
 									<li><a href="left-sidebar.html">Left Sidebar</a></li>
 									<li class="break"><a href="right-sidebar.html">Right Sidebar</a></li>
-									<li><a href="no-sidebar.html">No Sidebar</a></li>
+                                                                        <li><a href="no-sidebar.html">No Sidebar</a></li>
+                                                                        <li><a href="moneris-checkout.html">Moneris Demo</a></li>
 								</ul>
 							</nav>
 

--- a/server/moneris-checkout-server.js
+++ b/server/moneris-checkout-server.js
@@ -1,0 +1,123 @@
+import express from 'express';
+import fetch from 'node-fetch';
+import dotenv from 'dotenv';
+import { randomUUID } from 'crypto';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+dotenv.config();
+
+const app = express();
+const PORT = process.env.PORT || 5174;
+const MONERIS_URL = process.env.MONERIS_URL || 'https://gateway.moneris.com/chkt/request/request.php';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+app.use(express.json());
+app.use(express.static(ROOT_DIR));
+
+function validateEnv() {
+  const missing = [];
+  if (!process.env.MONERIS_STORE_ID) missing.push('MONERIS_STORE_ID');
+  if (!process.env.MONERIS_API_TOKEN) missing.push('MONERIS_API_TOKEN');
+  if (missing.length) {
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+  }
+}
+
+function buildCheckoutPayload(body = {}) {
+  const { amount, orderId, transactionType } = body;
+  if (!amount) {
+    throw new Error('Amount is required.');
+  }
+
+  validateEnv();
+
+  const checkoutId = body.checkoutId || `demo-${Date.now()}-${randomUUID().slice(0, 8)}`;
+  const environment = (process.env.MONERIS_ENV || 'qa').toLowerCase();
+
+  return {
+    request: {
+      store_id: process.env.MONERIS_STORE_ID,
+      api_token: process.env.MONERIS_API_TOKEN,
+      checkout_id: checkoutId,
+      txn_total: Number(amount).toFixed(2),
+      transaction_type: (transactionType || 'purchase').toLowerCase(),
+      order_no: orderId || checkoutId,
+      environment,
+      redirect_url: body.redirectUrl,
+      status_callback_url: body.statusCallbackUrl,
+      dynamic_descriptor: body.dynamicDescriptor || process.env.MONERIS_DESCRIPTOR,
+      customer_id: body.customerId,
+      email: body.email,
+      billing: body.billing,
+      shipping: body.shipping,
+    },
+  };
+}
+
+async function createCheckout(body) {
+  const payload = buildCheckoutPayload(body);
+  const response = await fetch(MONERIS_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const text = await response.text();
+  let json;
+  try {
+    json = JSON.parse(text);
+  } catch (error) {
+    json = { raw: text };
+  }
+
+  if (!response.ok) {
+    const message = json?.response?.error_message || json?.error || response.statusText;
+    const err = new Error(message);
+    err.status = response.status;
+    err.details = json;
+    throw err;
+  }
+
+  const checkoutId = json?.response?.checkout_id || json?.checkout_id || json?.id;
+  if (!checkoutId) {
+    const err = new Error('Checkout ID was not returned by Moneris.');
+    err.details = json;
+    throw err;
+  }
+
+  return {
+    checkoutId,
+    environment: payload.request.environment,
+    moneris: json,
+  };
+}
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.get('/', (_req, res) => {
+  res.sendFile(path.join(ROOT_DIR, 'moneris-checkout.html'));
+});
+
+app.post('/api/moneris/checkout', async (req, res) => {
+  try {
+    const result = await createCheckout(req.body);
+    res.json(result);
+  } catch (error) {
+    const status = error.status || 500;
+    res.status(status).json({
+      message: error.message,
+      details: error.details,
+    });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Moneris demo server listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a dedicated `moneris-checkout.html` guide that walks through hosted checkout and tokenization flows
- create the front-end controller and styling required to request checkout sessions and launch the Moneris widgets
- add an Express helper API plus npm metadata so QA credentials can be used to generate checkout IDs locally

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_69013ff528048322a10389ea15c82a57